### PR TITLE
remove trailing whitespace for passing PEP8-check

### DIFF
--- a/keras_contrib/applications/resnet.py
+++ b/keras_contrib/applications/resnet.py
@@ -146,7 +146,7 @@ def _residual_block(block_function, filters, blocks, stage,
     if transition_strides is None:
         transition_strides = [(1, 1)] * blocks
     if dilation_rates is None:
-        dilation_rates = [1] * blocks    
+        dilation_rates = [1] * blocks
 
     def f(x):
         for i in range(blocks):


### PR DESCRIPTION
The CI tests for PR https://github.com/keras-team/keras-contrib/pull/224 currently fails because of:
```
__________________ PEP8-check(ignoring E501 \ E402 \ E731 \) ___________________
/home/travis/build/keras-team/keras-contrib/keras_contrib/applications/resnet.py:149:38: W291 trailing whitespace
        dilation_rates = [1] * blocks
```
The commit removes the white space.